### PR TITLE
make lesson suitable for teaching with locally-built (serverless) pages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -48,19 +48,28 @@ start_time: 0
 collections:
   episodes:
     output: true
-    permalink: /:path/
+    permalink: /:path/index.html
   extras:
     output: true
+    permalink: /:path/index.html
 
 # Set the default layout for things in the episodes collection.
 defaults:
   - values:
-      root: ..
+      root: .
+      layout: page
   - scope:
       path: ""
       type: episodes
     values:
+      root: ..
       layout: episode
+  - scope:
+      path: ""
+      type: extras
+    values:
+      root: ..
+      layout: page
 
 # Files and directories that are not to be copied.
 exclude:

--- a/_extras/about.md
+++ b/_extras/about.md
@@ -1,6 +1,4 @@
 ---
-layout: page
 title: About
-permalink: /about/
 ---
 {% include carpentries.html %}

--- a/_extras/discuss.md
+++ b/_extras/discuss.md
@@ -1,7 +1,5 @@
 ---
-layout: page
 title: Discussion
-permalink: /discuss/
 ---
 
 There are many ways to discuss Library Carpentry lessons:

--- a/_extras/figures.md
+++ b/_extras/figures.md
@@ -1,6 +1,4 @@
 ---
-layout: page
 title: Figures
-permalink: /figures/
 ---
 {% include all_figures.html %}

--- a/_extras/guide.md
+++ b/_extras/guide.md
@@ -1,7 +1,5 @@
 ---
-layout: page
-title: "Instructor Notes"
-permalink: /guide/
+title: Instructor Notes
 ---
 
 ____
@@ -35,7 +33,7 @@ _____
 ## 04-regular-expressions.md 05-quiz.md 06-quiz-answers.md
 
 You may find it useful to use slides to work through episode four (see below for potential slides). Before starting the exercise, encourage learners to work with pen and paper, explain that with regex there are sometimes multiple answers to the same question (that is, some regex is perfect and some does the job given the likely data structures we use) and point them towards places to test their regex: for example regex101 [https://regex101.com/](https://regex101.com/), rexegper [http://regexper.com/](http://regexper.com/), myregexp [http://myregexp.com/]([http://myregexp.com/]), or whichever service you prefer. Also point them towards the quiz (episode five and six) as something they may move onto if they they finish the exercises early or look at after the workshop.
-  
+
 ____
 # General notes on Data Intro
 

--- a/_extras/guide.md
+++ b/_extras/guide.md
@@ -8,7 +8,7 @@ ____
 ____
 ## Making a handout
 
-Librarians like handouts. To make a handout for this lesson, adapt/print from [https://librarycarpentry.org/lc-data-intro-archives/reference/](https://librarycarpentry.org/lc-data-intro-archives/reference/).
+Librarians like handouts. To make a handout for this lesson, adapt/print from [the lesson reference page]({{page.root}}/reference.html).
 
 ____
 ## 02-jargon-busting.md

--- a/index.md
+++ b/index.md
@@ -1,6 +1,7 @@
 ---
 layout: lesson
 root: .
+permalink: index.html
 ---
 This Library Carpentry lesson introduces archivists to working with data. At the conclusion of the lesson you will: be able to explain terms, phrases, and concepts in code or software development; identify and use best practice in data structures; use regular expressions in searches.
 
@@ -8,4 +9,3 @@ This Library Carpentry lesson introduces archivists to working with data. At the
 >
 > This lesson has no prerequisites. Ideally you will need a laptop and an internet connection, though this is not required.
 {: .prereq}
-

--- a/reference.md
+++ b/reference.md
@@ -1,7 +1,5 @@
 ---
-layout: reference
 title: Reference
-permalink: /reference/
 ---
 
 # Regular Expressions Cheat Sheet
@@ -14,7 +12,7 @@ permalink: /reference/
 - `\s` matches any space, tab, or newline
 - `^` asserts the position at the start of the line. So what you put after it will only match if they are the first characters of a line.
 - `$` asserts the position at the end of the line. So what you put before it will only match if they are the last characters of a line.
-- `\b` adds a word boundary. Putting this either side of a stops the regular expression matching longer variants of words. 
+- `\b` adds a word boundary. Putting this either side of a stops the regular expression matching longer variants of words.
 - `*` matches the preceding element zero or more times. For example, `ab*c` matches "ac", "abc", "abbbc", etc.
 - `+` matches the preceding element one or more times. For example, `ab+c` matches "abc", "abbbc" but not "ac".
 - `?` matches when the preceding character appears one or zero times

--- a/setup.md
+++ b/setup.md
@@ -1,7 +1,5 @@
 ---
-layout: page
 title: Setup
-permalink: /setup/
 ---
 1. Installation instructions for core lessons are included in the [workshop template's home page][template],
    so that they are all in one place.


### PR DESCRIPTION
See discussion here for more background: https://github.com/datacarpentry/datacarpentry.github.io/issues/542

In short, some Carpentries lessons use the path `/guide/` for their Instructor Notes page and others use `/guide/index.html` (the default defined in `_config.yml`). This PR removes permalinks with a trailing slash from the YAML front matter of the Instructor Notes (`_extras/guide.md`) and other Extras files, consistent with new lessons created with [the lesson template](https://github.com/carpentries/styles/). Although there's no functional difference in the online versions of the lesson pages, pages with a trailing slash in the permalink will result in **broken links in the version of the lesson built locally**. We'd like local builds to be usable e.g. in workshops taking place at locations with limited or unreliable Internet access. 

Keeping the paths to these files consistent will also help us avoid broken links on the [Library Carpentry Lessons page](https://librarycarpentry.org/lessons/), and ensure that equivalent paths in new lessons created with the template are consistent with previously-developed lessons like this one.

I did a sweep through the lesson and found no internal links that need to be adjusted as part of this PR. If and when this is merged, I'll also make sure the link on https://librarycarpentry.org/lessons/ to the Instructor Notes page isn't broken, and make another sweep through the lesson pages too. 

Finally, I also removed the `layout` field from several pages, as the default layout is already set for Episodes and Extras pages in `_config.yml`.