### PR TITLE
Correct * to + in reg ex

### DIFF
--- a/_episodes/04-regular-expressions.md
+++ b/_episodes/04-regular-expressions.md
@@ -68,7 +68,7 @@ So, what is `^[Oo]rgani.e\b` going to match.
 Other useful special characters are:
 
 - `*` matches the preceding element zero or more times. For example, ab*c matches "ac", "abc", "abbbc", etc.
-- `+` matches the preceding element one or more times. For example, ab*c matches "abc", "abbbc" but not "ac".
+- `+` matches the preceding element one or more times. For example, ab+c matches "abc", "abbbc" but not "ac".
 - `?` matches when the preceding character appears zero or one time.
 - `{VALUE}` matches the preceding character the number of times define by VALUE; ranges can be specified with the syntax `{VALUE,VALUE}`
 - `|` means or.


### PR DESCRIPTION
Submitted by email from a learner. 

The + sign dot point actually shows the * instead of the + hence it should say "For example, ab+c matches "abc", "abbbc" but not "ac"."
